### PR TITLE
fix on README, send request using parameter, add example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ branches:
     - master
 
 install:
-    - rakudobrew build-panda
-    - panda install HTTP::UserAgent JSON::Tiny
+    - rakudobrew build-zef
+    - zef install HTTP::UserAgent JSON::Tiny

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A genuine Perl 6 client for the [Telegram's Bot API](https://core.telegram.org/b
 ## Example
 
 ```perl6
-use Telegram;
+use TelegramBot;
 
 my $token = "xxx:yyy"; # replace with your token
 my $bot = Telegram::Bot.new($token);

--- a/examples/getUpdates.p6
+++ b/examples/getUpdates.p6
@@ -1,0 +1,16 @@
+my $token = "xxx:yyy"; # replace with your token
+my $bot = Telegram::Bot.new($token);
+
+# get update
+my $updates = $bot.get-updates();
+#my $updates = $bot.get-updates({offset => xxxxx, limit => 1}); # with offset and limit
+
+# iterate through updates
+for 0 .. ($updates.elems - 1) -> $item
+{
+    say $updates[$item].update_id;      # update_id attribute
+    say $updates[$item].message.date;   # date attribute
+    say $updates[$item].message.text;   # text attribute
+    say $updates[$item].message.^methods; # get other available methods / attributes
+}
+

--- a/lib/Telegram.pm6
+++ b/lib/Telegram.pm6
@@ -28,7 +28,6 @@ class Telegram::Bot {
       my $q-str = do if %http-params != 0 {
         my @http-params-str;
         for %http-params.kv -> $k, $v {
-            say "my key $k, value $v";
           my $k2 = $k.subst("-", "_");
           push @http-params-str, "$k2=$v";
         }

--- a/lib/Telegram.pm6
+++ b/lib/Telegram.pm6
@@ -26,16 +26,17 @@ class Telegram::Bot {
     my $url = self!build-url($method-name);
     my $resp = do if $request-type == RequestType::Get {
       my $q-str = do if %http-params != 0 {
-        my $http-params-str;
+        my @http-params-str;
         for %http-params.kv -> $k, $v {
+            say "my key $k, value $v";
           my $k2 = $k.subst("-", "_");
-          $http-params-str += "$k2=$v";
+          push @http-params-str, "$k2=$v";
         }
 
-        $http-params-str
+        @http-params-str.join('&');
       }
 
-      $q-str ?? $!http-client.get($url + $q-str) !! $!http-client.get($url)
+      $q-str ?? $!http-client.get($url ~ '?' ~ $q-str) !! $!http-client.get($url);
     } else {
       my %http-params-formatted;
       for %http-params.kv -> $k, $v {


### PR DESCRIPTION
Rakudo Star 2018.04.1 and Rakudo 2018.05
Tested on Mac High Sierra and CentOS 7.

- after 'zef install TelegramBot', importing 'use Telegram' failed, it didn't error if using 'use TelegramBot'.

- sending request with param failed with '+=' string concat

- multiple query parameter is not separated correctly

- adding example for getUpdates

